### PR TITLE
Persist bundle

### DIFF
--- a/flow-typed/_custom-defs.js
+++ b/flow-typed/_custom-defs.js
@@ -38,3 +38,5 @@ declare type ReactNavigation$WithNavigationProps = $Exact<
 
 declare type Dispatch = Redux$Dispatch<*>;
 declare type GetState = () => StoreState;
+type _Return<R, Fn: (...args: Array<any>) => R> = R;
+declare type $ReturnType<T> = _Return<*, T>;

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -127,3 +127,10 @@ jest.mock('react-native-status-bar-height', () => ({
 // ./src/containers/with-layout
 
 jest.mock('./src/containers/with-layout');
+
+// redux-persist
+
+jest.mock('redux-persist', () => ({
+  persistReducer: (config, rootReducer) => rootReducer,
+  persistStore: store => store
+}));

--- a/package.json
+++ b/package.json
@@ -105,9 +105,10 @@
     "react-navigation": "^3.0.1",
     "react-redux": "^6.0.0",
     "redux": "^4.0.1",
+    "redux-persist": "^5.10.0",
     "redux-thunk": "^2.3.0",
-    "rn-placeholder": "^2.0.0",
     "rn-fetch-blob": "0.10.13",
+    "rn-placeholder": "^2.0.0",
     "semver": "^5.7.0"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,7 @@ import createDataLayer from './layer/data';
 import createServices from './services';
 import createStore from './redux';
 import type {ReduxDevTools} from './redux/_types';
+import {PersistGate} from 'redux-persist/integration/react';
 
 const reduxDevTools: ReduxDevTools | void =
   // eslint-disable-next-line no-undef
@@ -25,7 +26,7 @@ const reduxDevTools: ReduxDevTools | void =
 
 const dataLayer = createDataLayer(translations.getLanguage());
 const services = createServices(dataLayer);
-const store = createStore(services, reduxDevTools);
+const {store, persistor} = createStore(services, reduxDevTools);
 
 type Props = {||};
 
@@ -49,17 +50,19 @@ class App extends React.PureComponent<Props> {
   render() {
     return (
       <Provider store={store}>
-        <AnalyticsProvider>
-          <PortalProvider>
-            <VersionListener />
-            <BrandThemeProvider>
-              <View style={styles.container}>
-                <Navigator />
-              </View>
-            </BrandThemeProvider>
-            {Platform.OS === 'android' && <VideoFullscreenListener />}
-          </PortalProvider>
-        </AnalyticsProvider>
+        <PersistGate loading={null} persistor={persistor}>
+          <AnalyticsProvider>
+            <PortalProvider>
+              <VersionListener />
+              <BrandThemeProvider>
+                <View style={styles.container}>
+                  <Navigator />
+                </View>
+              </BrandThemeProvider>
+              {Platform.OS === 'android' && <VideoFullscreenListener />}
+            </PortalProvider>
+          </AnalyticsProvider>
+        </PersistGate>
       </Provider>
     );
   }

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -8,7 +8,6 @@ const create = (services: Services, reduxDevTools?: ReduxDevTools) => {
   const options: Options = {
     services
   };
-
   return createStore(options, reduxDevTools);
 };
 

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,6 +1,8 @@
 // @flow strict
 
+import {AsyncStorage} from 'react-native';
 import {applyMiddleware, combineReducers, compose, createStore} from 'redux';
+import {persistStore, persistReducer} from 'redux-persist';
 import {middlewares, reducers as storeReducers} from '@coorpacademy/player-store';
 import type {ReduxState} from '@coorpacademy/player-store';
 
@@ -73,8 +75,15 @@ const createMiddlewares = (options: Options, reduxDevTools?: ReduxDevTools) => {
     reduxDevTools || (f => f)
   );
 };
-const create = (options: Options, reduxDevTools?: ReduxDevTools) =>
+const create = (options: Options, reduxDevTools?: ReduxDevTools) => {
   // $FlowFixMe
-  createStore(reducers, {}, createMiddlewares(options, reduxDevTools));
+  const store = createStore(reducers, {}, createMiddlewares(options, reduxDevTools));
+  const persistedStore = persistStore(store, {
+    storage: AsyncStorage,
+    whitelist: ['bundle']
+  });
+
+  return persistedStore;
+};
 
 export default create;

--- a/src/redux/utils/reset-on-logout.js
+++ b/src/redux/utils/reset-on-logout.js
@@ -1,10 +1,14 @@
 // @flow strict
-import {SIGN_OUT} from '../actions/authentication';
 
-const resetOnLogout = <S, A: {type: string}>(reducer: (state?: S, action: A) => S) => (
-  state?: S,
-  action: A
-): S => {
+import type {Reducer} from 'redux';
+
+import {SIGN_OUT} from '../actions/authentication';
+import type {StoreAction} from '../_types';
+
+const resetOnLogout = <S, A: StoreAction<*>>(reducer: Reducer<S, A>): Reducer<S, A> => (
+  state,
+  action
+) => {
   switch (action.type) {
     case SIGN_OUT: {
       return reducer(undefined, action);

--- a/src/utils/tests.js
+++ b/src/utils/tests.js
@@ -10,7 +10,7 @@ import {__TEST__} from '../modules/environment';
 import type {Layout} from '../containers/with-layout';
 import type {State as AnalyticsState} from '../components/analytics-provider';
 
-export const store = createStore(createServices(createDataLayer('en')));
+export const {store} = createStore(createServices(createDataLayer('en')));
 
 // eslint-disable-next-line no-console
 export const handleFakePress = () => console.log('Fake press');

--- a/yarn.lock
+++ b/yarn.lock
@@ -11725,6 +11725,11 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
+redux-persist@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.npmjs.org/redux-persist/-/redux-persist-5.10.0.tgz#5d8d802c5571e55924efc1c3a9b23575283be62b"
+  integrity sha512-sSJAzNq7zka3qVHKce1hbvqf0Vf5DuTVm7dr4GtsqQVOexnrvbV47RWFiPxQ8fscnyiuWyD2O92DOxPl0tGCRg==
+
 redux-thunk@^2.2.0, redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"


### PR DESCRIPTION
## Detailed purpose of the PR

This PR persists bundle state (remember, only the keys are stored in this one) and rehydrates it at start to be synchronized with offline elements previously stored in async storage.

### Result and observation

When no bundle has been fetched yet:

![Capture d’écran 2019-06-03 à 16 37 34](https://user-images.githubusercontent.com/8419208/58810274-e96e3c00-861d-11e9-9697-f8ac1c63500c.png)

When bundled was previously fetched:

![Capture d’écran 2019-06-03 à 16 40 53](https://user-images.githubusercontent.com/8419208/58810519-5eda0c80-861e-11e9-83e8-f0824d5c016d.png)

- [ ] **Breaking changes ?**
- [x] **Extra dependency ?** `redux-persist@5` that we'll be able to use with `redux-offline` once we'll start discussing on it 

### Testing Strategy

- [x] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
