### PR TITLE
Dashboard render optimization

### DIFF
--- a/flow-typed/_custom-defs.js
+++ b/flow-typed/_custom-defs.js
@@ -21,6 +21,8 @@ declare type File = number;
 // Helper
 
 declare type $ExtractPropType = <T, R>(props: R) => R;
+type _ExtractReturn<B, F: (...args: any[]) => B> = B;
+declare type $ExtractReturn<F> = _ExtractReturn<*, F>;
 
 // React native types
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "hoist-non-react-statics": "^3.2.1",
     "jsc-android": "^241213.2.0",
     "jwt-decode": "^2.2.0",
+    "lodash": "^4.17.15",
     "p-map": "^2.1.0",
     "react": "16.8.3",
     "react-native": "0.59.9",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,8 @@
     "react-redux": "^7.0.3",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
+    "reselect": "^4.0.0",
+    "reselect-map": "^1.0.4",
     "rn-fetch-blob": "0.10.15",
     "rn-placeholder": "^2.0.0",
     "semver": "^6.1.1"

--- a/src/__fixtures__/store.js
+++ b/src/__fixtures__/store.js
@@ -65,6 +65,7 @@ export const createCatalogState = (
   sections?: Array<Section | void> = [],
   cards?: Array<DisciplineCard | ChapterCard> = []
 ): CatalogState => ({
+  sectionsRef: sections.map(section => (section ? section.key : undefined)),
   entities: {
     sections: sections.reduce((result, section) => {
       if (section) {

--- a/src/__fixtures__/store.js
+++ b/src/__fixtures__/store.js
@@ -6,9 +6,17 @@ import type {
 } from '@coorpacademy/player-store';
 import type {Slide as SlideEngine, Progression} from '@coorpacademy/progression-engine';
 import type {SlideAPI, ChapterAPI, LevelAPI} from '@coorpacademy/player-services';
-import type {Level, Slide, Chapter, Discipline} from '../layer/data/_types';
+
+import type {Section} from '../types';
+import type {
+  Level,
+  Slide,
+  Chapter,
+  Discipline,
+  DisciplineCard,
+  ChapterCard
+} from '../layer/data/_types';
 import type {StoreState} from '../redux/store';
-import {initialState as defaultCatalog} from '../redux/reducers/catalog';
 import type {State as CatalogState} from '../redux/reducers/catalog';
 import {initialState as permissionsState} from '../redux/reducers/permissions';
 import {mapToLevel, mapToSlide, mapToChapter, mapToDiscipline} from './utils/mappers';
@@ -52,6 +60,26 @@ const reduceToMappedObject = <T: MappableObject>(
 export const createMapObject = <T: MappableObject>(items: Array<T>): {[key: string]: T} => {
   return items.reduce(reduceToMappedObject, {});
 };
+
+export const createCatalogState = (
+  sections?: Array<Section | void> = [],
+  cards?: Array<DisciplineCard | ChapterCard> = []
+): CatalogState => ({
+  entities: {
+    sections: sections.reduce((result, section) => {
+      if (section) {
+        return {...result, [section.key]: {en: section}};
+      }
+      return result;
+    }, {}),
+    cards: cards.reduce((result, card) => {
+      if (card) {
+        return {...result, [card.universalRef]: {en: card}};
+      }
+      return result;
+    }, {})
+  }
+});
 
 export const createStoreState = ({
   levels,
@@ -180,7 +208,7 @@ export const createStoreState = ({
       currentScreenName: 'dummyScreenName',
       currentTabName: 'dummyScreenName'
     },
-    catalog: catalog || defaultCatalog,
+    catalog: catalog || createCatalogState(),
     permissions: permissionsState,
     authentication,
     godmode,

--- a/src/__fixtures__/store.test.js
+++ b/src/__fixtures__/store.test.js
@@ -119,6 +119,7 @@ describe('storeFixture', () => {
     };
 
     const catalogState = {
+      sectionsRef: [],
       entities: {
         cards: {},
         sections: {}
@@ -133,7 +134,9 @@ describe('storeFixture', () => {
       brand: null
     };
 
-    const permissionsState = {};
+    const permissionsState = {
+      camera: undefined
+    };
 
     const godModeState = false;
     const fastSlideState = false;
@@ -192,7 +195,9 @@ describe('storeFixture', () => {
         entities: {}
       },
       nextContent: {
-        entities: {}
+        entities: {
+          progression1: undefined
+        }
       }
     };
 

--- a/src/components/catalog-section.js
+++ b/src/components/catalog-section.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {View, StyleSheet, FlatList} from 'react-native';
 
 import theme from '../modules/theme';
+import isEqual from '../modules/equal';
 import translations from '../translations';
 import type {DisciplineCard, ChapterCard} from '../layer/data/_types';
 import {CARD_TYPE} from '../layer/data/_const';
@@ -63,6 +64,18 @@ class CatalogSection extends React.Component<Props> {
   props: Props;
 
   offsetX: number = 0;
+
+  shouldComponentUpdate({cards: nextCards, ...nextProps}: Props) {
+    const {cards, ...props} = this.props;
+
+    return (
+      typeof cards !== typeof nextCards ||
+      (cards &&
+        nextCards &&
+        cards.filter(card => card).length !== nextCards.filter(card => card).length) ||
+      !isEqual(props, nextProps)
+    );
+  }
 
   keyExtractor = (item: DisciplineCard | ChapterCard | void, index: number) => {
     const {sectionRef, testID} = this.props;

--- a/src/components/catalog-section.js
+++ b/src/components/catalog-section.js
@@ -4,7 +4,6 @@ import * as React from 'react';
 import {View, StyleSheet, FlatList} from 'react-native';
 
 import theme from '../modules/theme';
-import isEqual from '../modules/equal';
 import translations from '../translations';
 import type {DisciplineCard, ChapterCard} from '../layer/data/_types';
 import {CARD_TYPE} from '../layer/data/_const';
@@ -64,18 +63,6 @@ class CatalogSection extends React.Component<Props> {
   props: Props;
 
   offsetX: number = 0;
-
-  shouldComponentUpdate({cards: nextCards, ...nextProps}: Props) {
-    const {cards, ...props} = this.props;
-
-    return (
-      typeof cards !== typeof nextCards ||
-      (cards &&
-        nextCards &&
-        cards.filter(card => card).length !== nextCards.filter(card => card).length) ||
-      !isEqual(props, nextProps)
-    );
-  }
 
   keyExtractor = (item: DisciplineCard | ChapterCard | void, index: number) => {
     const {sectionRef, testID} = this.props;
@@ -157,6 +144,7 @@ class CatalogSection extends React.Component<Props> {
 
   render() {
     const {sectionRef, cards, onScroll, testID} = this.props;
+
     return (
       <View>
         {this.renderTitle()}

--- a/src/components/catalog.js
+++ b/src/components/catalog.js
@@ -11,12 +11,10 @@ import Space from './space';
 
 export type Props = {|
   sections: Array<Section | void>,
-  cards: Array<DisciplineCard | ChapterCard>,
   onCardPress: (DisciplineCard | ChapterCard) => void,
   onRefresh: () => void,
   isRefreshing?: boolean,
   onScroll: ScrollEvent => void,
-  onCardsScroll: (Section, offset: number, limit: number) => void,
   children?: React.Node
 |};
 
@@ -30,12 +28,8 @@ const SEPARATOR_SIZE = 'small';
 export const SEPARATOR_HEIGHT = theme.spacing[SEPARATOR_SIZE];
 const PLACEHOLDER_LENGTH = 3;
 
-class Catalog extends React.PureComponent<Props> {
+class Catalog extends React.Component<Props> {
   props: Props;
-
-  handleCardsScroll = (section: Section) => (offset: number, limit: number) => {
-    this.props.onCardsScroll(section, offset, limit);
-  };
 
   keyExtractor = (item: Section | void, index: number) => {
     const suffix = (item && item.key) || `${index}-placeholder`;
@@ -44,23 +38,18 @@ class Catalog extends React.PureComponent<Props> {
   };
 
   renderItem = ({item, index}: {item: Section | void, index: number}) => {
-    const {cards, onCardPress} = this.props;
+    const {onCardPress} = this.props;
     const testID = this.keyExtractor(item, index);
 
     if (!item) {
       return <CatalogSection testID={testID} />;
     }
 
-    const sectionCards =
-      item.cardsRef && item.cardsRef.map(ref => cards.find(card => card.universalRef === ref));
-
     return (
       <CatalogSection
         title={item.title}
         sectionRef={item.key}
-        cards={sectionCards}
         onCardPress={onCardPress}
-        onScroll={this.handleCardsScroll(item)}
         testID={testID}
       />
     );

--- a/src/components/catalog.stories.js
+++ b/src/components/catalog.stories.js
@@ -2,12 +2,12 @@
 
 import * as React from 'react';
 import {storiesOf} from '@storybook/react-native';
-import renderer from 'react-test-renderer';
 
 import {createSections} from '../__fixtures__/sections';
 import {createCardLevel, createDisciplineCard, createChapterCard} from '../__fixtures__/cards';
+import {createCatalogState} from '../__fixtures__/store';
 import {CARD_STATUS} from '../layer/data/_const';
-import {handleFakePress} from '../utils/tests';
+import {handleFakePress, TestContextProvider} from '../utils/tests';
 import {__TEST__} from '../modules/environment';
 import Catalog from './catalog';
 
@@ -46,69 +46,49 @@ const chapterCard = createChapterCard({
 
 storiesOf('Catalog', module)
   .add('Default', () => (
-    <Catalog
-      sections={[]}
-      cards={[]}
-      onCardPress={handleFakePress}
-      onRefresh={handleFakePress}
-      onCardsScroll={handleFakePress}
-      onScroll={handleFakePress}
-    />
+    <TestContextProvider store={{catalog: createCatalogState([], [])}}>
+      <Catalog
+        sections={[]}
+        onCardPress={handleFakePress}
+        onRefresh={handleFakePress}
+        onScroll={handleFakePress}
+      />
+    </TestContextProvider>
   ))
   .add('Refreshing', () => (
-    <Catalog
-      sections={[]}
-      cards={[]}
-      onCardPress={handleFakePress}
-      onRefresh={handleFakePress}
-      onCardsScroll={handleFakePress}
-      onScroll={handleFakePress}
-      isRefreshing
-    />
+    <TestContextProvider store={{catalog: createCatalogState([], [])}}>
+      <Catalog
+        sections={[]}
+        onCardPress={handleFakePress}
+        onRefresh={handleFakePress}
+        onScroll={handleFakePress}
+        isRefreshing
+      />
+    </TestContextProvider>
   ))
   .add('Sections with cards', () => (
-    <Catalog
-      sections={sectionsWithCardsRef}
-      cards={[disciplineCard, chapterCard]}
-      onCardPress={handleFakePress}
-      onRefresh={handleFakePress}
-      onCardsScroll={handleFakePress}
-      onScroll={handleFakePress}
-    />
+    <TestContextProvider
+      store={{catalog: createCatalogState(sectionsWithCardsRef, [disciplineCard, chapterCard])}}
+    >
+      <Catalog
+        sections={sectionsWithCardsRef}
+        onCardPress={handleFakePress}
+        onRefresh={handleFakePress}
+        onScroll={handleFakePress}
+      />
+    </TestContextProvider>
   ))
   .add('Sections with bad card refs', () => (
-    <Catalog
-      sections={sectionsWithEmptyCardsRef}
-      cards={[disciplineCard, chapterCard]}
-      onCardPress={handleFakePress}
-      onRefresh={handleFakePress}
-      onCardsScroll={handleFakePress}
-      onScroll={handleFakePress}
-    />
+    <TestContextProvider
+      store={{
+        catalog: createCatalogState(sectionsWithEmptyCardsRef, [disciplineCard, chapterCard])
+      }}
+    >
+      <Catalog
+        sections={sectionsWithEmptyCardsRef}
+        onCardPress={handleFakePress}
+        onRefresh={handleFakePress}
+        onScroll={handleFakePress}
+      />
+    </TestContextProvider>
   ));
-
-if (__TEST__) {
-  describe('Catalog', () => {
-    it('should handle scroll', () => {
-      const handleCardsScroll = jest.fn();
-      const component = renderer.create(
-        <Catalog
-          sections={sectionsWithCardsRef}
-          cards={[disciplineCard, chapterCard]}
-          onCardPress={handleFakePress}
-          onRefresh={handleFakePress}
-          onCardsScroll={handleCardsScroll}
-          onScroll={handleFakePress}
-        />
-      );
-      const firstSection = sectionsWithCardsRef[0];
-      const catalogSection = component.root.find(
-        // $FlowFixMe from fixtures
-        el => el.props.testID === `catalog-section-${firstSection.key}`
-      );
-      catalogSection.props.onScroll(500, 3);
-      expect(handleCardsScroll.mock.calls.length).toBe(1);
-      expect(handleCardsScroll.mock.calls[0]).toEqual([firstSection, 500, 3]);
-    });
-  });
-}

--- a/src/containers/cards-swipable.test.js
+++ b/src/containers/cards-swipable.test.js
@@ -5,112 +5,109 @@ import renderer from 'react-test-renderer';
 
 import {ANALYTICS_EVENT_TYPE, CARD_TYPE, RESOURCE_TYPE} from '../const';
 import {createFakeAnalytics} from '../utils/tests';
-import {__TEST__} from '../modules/environment';
 import type {Card} from '../components/cards';
 import {Component as CardsSwipable} from './cards-swipable';
 
-if (__TEST__) {
-  describe('CardsSwipable', () => {
-    it('should handle onSwipe on resource card and forward analytics data', () => {
-      const dummyResourceCard: Card = {
-        type: CARD_TYPE.RESOURCE,
-        title: 'correction',
-        isCorrect: true,
-        resource: {
-          description: '',
-          videoId: 'KovTu3zU',
-          mediaRef: 'med_jwp_Vy4JQKFhN',
-          mimeType: 'application/jwplayer',
-          ref: 'plop',
-          _id: 'plop',
-          type: RESOURCE_TYPE.VIDEO,
-          subtitles: [],
-          posters: [],
-          src: [],
-          poster: '',
-          url: ''
-        },
-        offeringExtraLife: false
-      };
-      const renderItem = jest.fn();
-      const selectResource = jest.fn();
-      const analytics = createFakeAnalytics();
-
-      const component = renderer.create(
-        <CardsSwipable
-          analytics={analytics}
-          items={[dummyResourceCard]}
-          renderItem={renderItem}
-          selectResource={selectResource}
-        />
-      );
-
-      expect(selectResource).toHaveBeenCalledWith('plop');
-
-      const cards = component.root.find(el => el.props.testID === 'cards');
-      cards.props.onSwiped(0);
-
-      expect(analytics.logEvent).toHaveBeenCalledWith(ANALYTICS_EVENT_TYPE.SWIPE, {
-        id: 'deck-card',
-        isCorrect: 1,
-        offeringExtraLife: 0,
+describe('CardsSwipable', () => {
+  it('should handle onSwipe on resource card and forward analytics data', () => {
+    const dummyResourceCard: Card = {
+      type: CARD_TYPE.RESOURCE,
+      title: 'correction',
+      isCorrect: true,
+      resource: {
+        description: '',
+        videoId: 'KovTu3zU',
+        mediaRef: 'med_jwp_Vy4JQKFhN',
+        mimeType: 'application/jwplayer',
         ref: 'plop',
-        type: 'resource-video'
-      });
-    });
+        _id: 'plop',
+        type: RESOURCE_TYPE.VIDEO,
+        subtitles: [],
+        posters: [],
+        src: [],
+        poster: '',
+        url: ''
+      },
+      offeringExtraLife: false
+    };
+    const renderItem = jest.fn();
+    const selectResource = jest.fn();
+    const analytics = createFakeAnalytics();
 
-    it('should handle onSwipe on tip card card and forward analytics data', () => {
-      const dummyResourceCard: Card = {
-        type: CARD_TYPE.RESOURCE,
-        title: 'correction',
-        isCorrect: true,
-        resource: {
-          description: '',
-          videoId: 'KovTu3zU',
-          mediaRef: 'med_jwp_Vy4JQKFhN',
-          mimeType: 'application/jwplayer',
-          ref: 'plop',
-          _id: 'plop',
-          type: RESOURCE_TYPE.VIDEO,
-          subtitles: [],
-          posters: [],
-          src: [],
-          poster: '',
-          url: ''
-        },
-        offeringExtraLife: false
-      };
+    const component = renderer.create(
+      <CardsSwipable
+        analytics={analytics}
+        items={[dummyResourceCard]}
+        renderItem={renderItem}
+        selectResource={selectResource}
+      />
+    );
 
-      const dummyTipCard: Card = {
-        type: CARD_TYPE.TIP,
-        title: 'fooz',
-        isCorrect: false
-      };
+    expect(selectResource).toHaveBeenCalledWith('plop');
 
-      const renderItem = jest.fn();
-      const selectResource = jest.fn();
-      const analytics = createFakeAnalytics();
+    const cards = component.root.find(el => el.props.testID === 'cards');
+    cards.props.onSwiped(0);
 
-      const component = renderer.create(
-        <CardsSwipable
-          analytics={analytics}
-          items={[dummyTipCard, dummyResourceCard]}
-          renderItem={renderItem}
-          selectResource={selectResource}
-        />
-      );
-
-      expect(selectResource).not.toHaveBeenCalled();
-
-      const cards = component.root.find(el => el.props.testID === 'cards');
-      cards.props.onSwiped(0);
-
-      expect(selectResource).toHaveBeenCalledWith('plop');
-      expect(analytics.logEvent).toHaveBeenCalledWith(ANALYTICS_EVENT_TYPE.SWIPE, {
-        id: 'deck-card',
-        isCorrect: 0,
-        type: CARD_TYPE.TIP
-      });
+    expect(analytics.logEvent).toHaveBeenCalledWith(ANALYTICS_EVENT_TYPE.SWIPE, {
+      id: 'deck-card',
+      isCorrect: 1,
+      offeringExtraLife: 0,
+      ref: 'plop',
+      type: 'resource-video'
     });
   });
-}
+
+  it('should handle onSwipe on tip card card and forward analytics data', () => {
+    const dummyResourceCard: Card = {
+      type: CARD_TYPE.RESOURCE,
+      title: 'correction',
+      isCorrect: true,
+      resource: {
+        description: '',
+        videoId: 'KovTu3zU',
+        mediaRef: 'med_jwp_Vy4JQKFhN',
+        mimeType: 'application/jwplayer',
+        ref: 'plop',
+        _id: 'plop',
+        type: RESOURCE_TYPE.VIDEO,
+        subtitles: [],
+        posters: [],
+        src: [],
+        poster: '',
+        url: ''
+      },
+      offeringExtraLife: false
+    };
+
+    const dummyTipCard: Card = {
+      type: CARD_TYPE.TIP,
+      title: 'fooz',
+      isCorrect: false
+    };
+
+    const renderItem = jest.fn();
+    const selectResource = jest.fn();
+    const analytics = createFakeAnalytics();
+
+    const component = renderer.create(
+      <CardsSwipable
+        analytics={analytics}
+        items={[dummyTipCard, dummyResourceCard]}
+        renderItem={renderItem}
+        selectResource={selectResource}
+      />
+    );
+
+    expect(selectResource).not.toHaveBeenCalled();
+
+    const cards = component.root.find(el => el.props.testID === 'cards');
+    cards.props.onSwiped(0);
+
+    expect(selectResource).toHaveBeenCalledWith('plop');
+    expect(analytics.logEvent).toHaveBeenCalledWith(ANALYTICS_EVENT_TYPE.SWIPE, {
+      id: 'deck-card',
+      isCorrect: 0,
+      type: CARD_TYPE.TIP
+    });
+  });
+});

--- a/src/containers/catalog-section-refreshable.js
+++ b/src/containers/catalog-section-refreshable.js
@@ -55,7 +55,7 @@ class CatalogSectionRefreshable extends React.Component<Props> {
         cards.filter(card => card).length !== nextCards.filter(card => card).length) ||
       !isEqual(props, nextProps)
     );
-  }
+  };
 
   getOffset = (offsetX: number): number => Math.trunc(offsetX / ITEM_WIDTH);
 
@@ -104,19 +104,22 @@ class CatalogSectionRefreshable extends React.Component<Props> {
   }
 }
 
-const getCardsRef = (state: StoreState, {sectionRef}: Props) =>
-  (sectionRef &&
-    state.catalog.entities.sections[sectionRef] &&
-    state.catalog.entities.sections[sectionRef][translations.getLanguage()] &&
-    state.catalog.entities.sections[sectionRef][translations.getLanguage()].cardsRef) ||
-  [];
+const getCardsRef = (state: StoreState, {sectionRef}: Props) => {
+  const cardsRef =
+    (sectionRef &&
+      state.catalog.entities.sections[sectionRef] &&
+      state.catalog.entities.sections[sectionRef][translations.getLanguage()] &&
+      state.catalog.entities.sections[sectionRef][translations.getLanguage()].cardsRef) ||
+    [];
+  return cardsRef;
+};
 
 const getCards = (state: StoreState) => state.catalog.entities.cards;
 
 const getCardsState = createArraySelector(
   [getCardsRef, getCards],
-  // @todo type
-  (cardRef: string | void, cards) => cards[cardRef] && cards[cardRef][translations.getLanguage()]
+  (cardRef: string | void, cards: $ExtractReturn<typeof getCards>) =>
+    cardRef && cards[cardRef] && cards[cardRef][translations.getLanguage()]
 );
 
 const mapStateToProps = (state: StoreState, props: Props): ConnectedStateProps => ({

--- a/src/containers/catalog-section-refreshable.js
+++ b/src/containers/catalog-section-refreshable.js
@@ -14,7 +14,7 @@ import translations from '../translations';
 import withLayout from './with-layout';
 import type {WithLayoutProps} from './with-layout';
 
-type ConnectedStateProps = {|
+export type ConnectedStateProps = {|
   cards: Array<DisciplineCard | ChapterCard | void>
 |};
 
@@ -22,20 +22,22 @@ type ConnectedDispatchProps = {|
   fetchCards: typeof fetchCards
 |};
 
+export type OwnProps = $Diff<
+  CatalogSectionProps,
+  {|
+    cards: $PropertyType<CatalogSectionProps, 'cards'>,
+    onScroll: $PropertyType<CatalogSectionProps, 'onScroll'>
+  |}
+>;
+
 type Props = {|
   ...ConnectedStateProps,
   ...ConnectedDispatchProps,
   ...WithLayoutProps,
-  ...$Diff<
-    CatalogSectionProps,
-    {|
-      cards: $PropertyType<CatalogSectionProps, 'cards'>,
-      onScroll: $PropertyType<CatalogSectionProps, 'onScroll'>
-    |}
-  >
+  ...OwnProps
 |};
 
-const DEBOUNCE_DURATION = 100;
+export const DEBOUNCE_DURATION = 100;
 
 class CatalogSectionRefreshable extends React.Component<Props> {
   props: Props;
@@ -104,7 +106,7 @@ class CatalogSectionRefreshable extends React.Component<Props> {
   }
 }
 
-const getCardsRef = (state: StoreState, {sectionRef}: Props) => {
+const getCardsRef = (state: StoreState, {sectionRef}: OwnProps) => {
   const cardsRef =
     (sectionRef &&
       state.catalog.entities.sections[sectionRef] &&
@@ -122,7 +124,7 @@ const getCardsState = createArraySelector(
     cardRef && cards[cardRef] && cards[cardRef][translations.getLanguage()]
 );
 
-const mapStateToProps = (state: StoreState, props: Props): ConnectedStateProps => ({
+export const mapStateToProps = (state: StoreState, props: OwnProps): ConnectedStateProps => ({
   cards: getCardsState(state, props)
 });
 
@@ -130,6 +132,7 @@ const mapDispatchToProps: ConnectedDispatchProps = {
   fetchCards
 };
 
+export {CatalogSectionRefreshable as Component};
 export default withLayout(
   connect(
     mapStateToProps,

--- a/src/containers/catalog-section-refreshable.js
+++ b/src/containers/catalog-section-refreshable.js
@@ -1,32 +1,61 @@
-// @flow strict
+// @flow
 
 import * as React from 'react';
+import {connect} from 'react-redux';
+import {createArraySelector} from 'reselect-map';
 
-import {DEFAULT_LIMIT} from '../redux/actions/catalog/cards/fetch';
+import {fetchCards, DEFAULT_LIMIT} from '../redux/actions/catalog/cards/fetch';
+import type {StoreState} from '../redux/store';
 import CatalogSection, {ITEM_WIDTH} from '../components/catalog-section';
 import type {Props as CatalogSectionProps} from '../components/catalog-section';
+import type {DisciplineCard, ChapterCard} from '../layer/data/_types';
+import isEqual from '../modules/equal';
+import translations from '../translations';
 import withLayout from './with-layout';
 import type {WithLayoutProps} from './with-layout';
 
+type ConnectedStateProps = {|
+  cards: Array<DisciplineCard | ChapterCard | void>
+|};
+
+type ConnectedDispatchProps = {|
+  fetchCards: typeof fetchCards
+|};
+
 type Props = {|
+  ...ConnectedStateProps,
+  ...ConnectedDispatchProps,
   ...WithLayoutProps,
   ...$Diff<
     CatalogSectionProps,
     {|
+      cards: $PropertyType<CatalogSectionProps, 'cards'>,
       onScroll: $PropertyType<CatalogSectionProps, 'onScroll'>
     |}
-  >,
-  onScroll?: (offset: number, limit: number) => void
+  >
 |};
 
 const DEBOUNCE_DURATION = 100;
 
-class CatalogSectionRefreshable extends React.PureComponent<Props> {
+class CatalogSectionRefreshable extends React.Component<Props> {
   props: Props;
 
   timeout: TimeoutID;
 
   offsetX: number = 0;
+
+  shouldComponentUpdate = ({cards: nextCards, ...nextProps}: Props) => {
+    const {cards, ...props} = this.props;
+
+    return (
+      typeof cards !== typeof nextCards ||
+      // For performance purpose only (prevent useless render)
+      (cards &&
+        nextCards &&
+        cards.filter(card => card).length !== nextCards.filter(card => card).length) ||
+      !isEqual(props, nextProps)
+    );
+  }
 
   getOffset = (offsetX: number): number => Math.trunc(offsetX / ITEM_WIDTH);
 
@@ -40,10 +69,10 @@ class CatalogSectionRefreshable extends React.PureComponent<Props> {
   };
 
   handleScroll = ({nativeEvent}: ScrollEvent) => {
-    const {onScroll, layout, cards} = this.props;
+    const {sectionRef, layout, cards} = this.props;
     const offsetX = nativeEvent.contentOffset.x;
 
-    if (offsetX !== this.offsetX && layout) {
+    if (sectionRef && offsetX !== this.offsetX && layout) {
       this.offsetX = offsetX;
       const offset = this.getOffset(offsetX);
       const limit = this.getLimit();
@@ -54,7 +83,7 @@ class CatalogSectionRefreshable extends React.PureComponent<Props> {
         clearTimeout(this.timeout);
         this.timeout = setTimeout(() => {
           if (this.offsetX === offsetX) {
-            onScroll && onScroll(offset, limit);
+            this.props.fetchCards(sectionRef, offset, limit);
           }
         }, DEBOUNCE_DURATION);
       }
@@ -64,7 +93,7 @@ class CatalogSectionRefreshable extends React.PureComponent<Props> {
   render() {
     const {
       /* eslint-disable no-unused-vars */
-      onScroll,
+      fetchCards: _fetchCards,
       containerStyle,
       layout,
       onLayout,
@@ -75,4 +104,32 @@ class CatalogSectionRefreshable extends React.PureComponent<Props> {
   }
 }
 
-export default withLayout(CatalogSectionRefreshable);
+const getCardsRef = (state: StoreState, {sectionRef}: Props) =>
+  (sectionRef &&
+    state.catalog.entities.sections[sectionRef] &&
+    state.catalog.entities.sections[sectionRef][translations.getLanguage()] &&
+    state.catalog.entities.sections[sectionRef][translations.getLanguage()].cardsRef) ||
+  [];
+
+const getCards = (state: StoreState) => state.catalog.entities.cards;
+
+const getCardsState = createArraySelector(
+  [getCardsRef, getCards],
+  // @todo type
+  (cardRef: string | void, cards) => cards[cardRef] && cards[cardRef][translations.getLanguage()]
+);
+
+const mapStateToProps = (state: StoreState, props: Props): ConnectedStateProps => ({
+  cards: getCardsState(state, props)
+});
+
+const mapDispatchToProps: ConnectedDispatchProps = {
+  fetchCards
+};
+
+export default withLayout(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(CatalogSectionRefreshable)
+);

--- a/src/containers/catalog-section-refreshable.test.js
+++ b/src/containers/catalog-section-refreshable.test.js
@@ -1,0 +1,137 @@
+// @flow
+
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+
+import {createSections} from '../__fixtures__/sections';
+import {createChapterCard} from '../__fixtures__/cards';
+import {createCatalogState, createStoreState} from '../__fixtures__/store';
+import {createProgression} from '../__fixtures__/progression';
+import {fakeLayout, handleFakePress} from '../utils/tests';
+import {CARD_STATUS} from '../layer/data/_const';
+import type {DisciplineCard, ChapterCard} from '../layer/data/_types';
+import {ENGINE, CONTENT_TYPE} from '../const';
+import {
+  Component as CatalogSectionRefreshable,
+  mapStateToProps,
+  DEBOUNCE_DURATION
+} from './catalog-section-refreshable';
+import type {ConnectedStateProps, OwnProps} from './catalog-section-refreshable';
+
+jest.useFakeTimers();
+
+const cards: Array<DisciplineCard | ChapterCard> = ['foo', 'bar', 'baz', 'qux', 'quux'].map(ref =>
+  createChapterCard({
+    ref,
+    completion: 0,
+    title: 'Fake chapter',
+    status: CARD_STATUS.ACTIVE
+  })
+);
+
+describe('CatalogSectionRefreshable', () => {
+  describe('onScroll', () => {
+    it('should fetch cards on scroll', () => {
+      const sectionRef = 'foo';
+      const fetchCards = jest.fn();
+      const _cards: Array<DisciplineCard | ChapterCard | void> = cards
+        .slice(0, 2)
+        .concat([undefined, undefined, undefined, undefined]);
+      const component = renderer.create(
+        <CatalogSectionRefreshable
+          sectionRef={sectionRef}
+          cards={_cards}
+          onCardPress={handleFakePress}
+          layout={fakeLayout}
+          fetchCards={fetchCards}
+          testID={`catalog-section-${sectionRef}`}
+        />
+      );
+      const catalogSection = component.root.find(
+        el => el.props.testID === `catalog-section-${sectionRef}-items`
+      );
+      const scrollEvent: ScrollEvent = {
+        nativeEvent: {
+          contentOffset: {
+            x: 453
+          }
+        }
+      };
+      catalogSection.props.onScroll(scrollEvent);
+      jest.advanceTimersByTime(DEBOUNCE_DURATION);
+      expect(fetchCards).toHaveBeenCalledTimes(1);
+      expect(fetchCards).toHaveBeenCalledWith(sectionRef, 2, 3);
+    });
+
+    it('should handle scroll on cards already fetched', () => {
+      const sectionRef = 'baz';
+      const fetchCards = jest.fn();
+      const _cards: Array<DisciplineCard | ChapterCard | void> = cards.concat([undefined]);
+      const component = renderer.create(
+        <CatalogSectionRefreshable
+          sectionRef={sectionRef}
+          cards={_cards}
+          onCardPress={handleFakePress}
+          layout={fakeLayout}
+          fetchCards={fetchCards}
+          testID={`catalog-section-${sectionRef}`}
+        />
+      );
+      const catalogSection = component.root.find(
+        el => el.props.testID === `catalog-section-${sectionRef}-items`
+      );
+      const scrollEvent: ScrollEvent = {
+        nativeEvent: {
+          contentOffset: {
+            x: 453
+          }
+        }
+      };
+      catalogSection.props.onScroll(scrollEvent);
+      jest.advanceTimersByTime(DEBOUNCE_DURATION);
+      expect(fetchCards).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    const sections = createSections();
+    const sectionsWithCardsRef = sections.map((section, index) => ({
+      ...section,
+      cardsRef:
+        (index === 0 && ['foo', 'bar', undefined]) ||
+        (index === 1 && ['bar', 'foo']) ||
+        (index === 2 && []) ||
+        undefined
+    }));
+    const catalog = createCatalogState(sectionsWithCardsRef, cards);
+
+    it('should get all props', () => {
+      const sectionRef = sections[0].key;
+      const levelRef = 'dummyRef';
+      const progression = createProgression({
+        engine: ENGINE.MICROLEARNING,
+        progressionContent: {
+          type: CONTENT_TYPE.LEVEL,
+          ref: levelRef
+        }
+      });
+
+      const mockedStore = createStoreState({
+        levels: [],
+        disciplines: [],
+        chapters: [],
+        slides: [],
+        progression,
+        catalog
+      });
+
+      const props: OwnProps = {sectionRef, testID: 'foobar'};
+      const result = mapStateToProps(mockedStore, props);
+      const expected: ConnectedStateProps = {
+        cards: cards.slice(0, 2).concat([undefined])
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/src/containers/catalog.js
+++ b/src/containers/catalog.js
@@ -60,11 +60,17 @@ class Catalog extends React.Component<Props, State> {
 
   shouldComponentUpdate({sections: nextSections, ...nextProps}: Props, nextState: State) {
     const {sections, ...props} = this.props;
+    const emptySections = sections.filter(s => s && isEmptySection(s));
+    const nextEmptySections = nextSections.filter(s => s && isEmptySection(s));
+    const placeholderSections = sections.filter(s => s && s.cardsRef === undefined);
+    const nextPlaceholderSections = nextSections.filter(s => s && s.cardsRef === undefined);
 
+    // For performance purpose only (prevent useless render)
     return (
-      !isEqual(this.state, nextState) ||
-      // For performance purpose only (prevent useless render)
       sections.length !== nextSections.length ||
+      emptySections.length !== nextEmptySections.length ||
+      placeholderSections.length !== nextPlaceholderSections.length ||
+      !isEqual(this.state, nextState) ||
       !isEqual(props, nextProps)
     );
   }
@@ -170,11 +176,8 @@ const getSections = (state: StoreState) => state.catalog.entities.sections;
 const getSectionsRef = (state: StoreState) => state.catalog.sectionsRef || [];
 const getSectionsState = createArraySelector(
   [getSectionsRef, getSections],
-  (sectionRef, sections) => {
-    const section =
-      sectionRef && sections[sectionRef] && sections[sectionRef][translations.getLanguage()];
-    return section && section.cardsRef !== null ? section : undefined;
-  }
+  (sectionRef, sections) =>
+    sectionRef && sections[sectionRef] && sections[sectionRef][translations.getLanguage()]
 );
 
 export const mapStateToProps = (state: StoreState): ConnectedStateProps => ({

--- a/src/containers/catalog.test.js
+++ b/src/containers/catalog.test.js
@@ -1,0 +1,154 @@
+// @flow
+
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+
+import {createSections} from '../__fixtures__/sections';
+import {createCatalogState, createStoreState} from '../__fixtures__/store';
+import {createProgression} from '../__fixtures__/progression';
+import {fakeLayout, handleFakePress, TestContextProvider} from '../utils/tests';
+import {ENGINE, CONTENT_TYPE} from '../const';
+import type {Section} from '../types';
+import {Component as Catalog, mapStateToProps, DEBOUNCE_DURATION, DEFAULT_LIMIT} from './catalog';
+import type {ConnectedStateProps} from './catalog';
+
+jest.useFakeTimers();
+
+const sections = createSections();
+const sectionsWithCardsRef = sections.map((section, index) => ({
+  ...section,
+  cardsRef:
+    (index === 0 && ['foo', 'bar', undefined]) ||
+    (index === 1 && ['bar', 'foo']) ||
+    (index === 2 && []) ||
+    undefined
+}));
+
+describe('Catalog', () => {
+  it('should fetch at mount', () => {
+    const fetchSections = jest.fn();
+    renderer.create(
+      <TestContextProvider>
+        <Catalog
+          sections={[]}
+          onCardPress={handleFakePress}
+          layout={fakeLayout}
+          fetchSections={fetchSections}
+        />
+      </TestContextProvider>
+    );
+
+    expect(fetchSections).toHaveBeenCalledTimes(1);
+    expect(fetchSections).toHaveBeenCalledWith(0, DEFAULT_LIMIT, false);
+  });
+
+  describe('onScroll', () => {
+    it('should fetch sections on scroll', () => {
+      const fetchSections = jest.fn();
+      const _sections: Array<Section | void> = sectionsWithCardsRef.concat([undefined]);
+      const component = renderer.create(
+        <TestContextProvider>
+          <Catalog
+            sections={_sections}
+            onCardPress={handleFakePress}
+            layout={fakeLayout}
+            fetchSections={fetchSections}
+          />
+        </TestContextProvider>
+      );
+      const catalog = component.root.find(el => el.props.testID === 'catalog');
+      const scrollEvent: ScrollEvent = {
+        nativeEvent: {
+          contentOffset: {
+            y: 580
+          }
+        }
+      };
+      catalog.props.onScroll(scrollEvent);
+      jest.advanceTimersByTime(DEBOUNCE_DURATION);
+      expect(fetchSections).toHaveBeenCalledTimes(2);
+      expect(fetchSections.mock.calls[0]).toEqual([0, 3, false]);
+      expect(fetchSections.mock.calls[1]).toEqual([2, 1, false]);
+    });
+
+    it('should handle scroll on sections already fetched', () => {
+      const fetchSections = jest.fn();
+      const _sections: Array<Section | void> = sectionsWithCardsRef;
+      const component = renderer.create(
+        <TestContextProvider>
+          <Catalog
+            sections={_sections}
+            onCardPress={handleFakePress}
+            layout={fakeLayout}
+            fetchSections={fetchSections}
+          />
+        </TestContextProvider>
+      );
+      const catalog = component.root.find(el => el.props.testID === 'catalog');
+      const scrollEvent: ScrollEvent = {
+        nativeEvent: {
+          contentOffset: {
+            y: 1
+          }
+        }
+      };
+      catalog.props.onScroll(scrollEvent);
+      jest.advanceTimersByTime(DEBOUNCE_DURATION);
+      expect(fetchSections).toHaveBeenCalledTimes(1);
+      expect(fetchSections.mock.calls[0]).toEqual([0, 2, false]);
+    });
+  });
+
+  describe('onRefresh', () => {
+    it('should handle refresh', () => {
+      const fetchSections = jest.fn();
+      const _sections: Array<Section | void> = sectionsWithCardsRef;
+      const component = renderer.create(
+        <TestContextProvider>
+          <Catalog
+            sections={_sections}
+            onCardPress={handleFakePress}
+            layout={fakeLayout}
+            fetchSections={fetchSections}
+          />
+        </TestContextProvider>
+      );
+      const catalog = component.root.find(el => el.props.testID === 'catalog');
+      catalog.props.onRefresh();
+      expect(fetchSections).toHaveBeenCalledTimes(2);
+      expect(fetchSections.mock.calls[0]).toEqual([0, 2, false]);
+      expect(fetchSections.mock.calls[1]).toEqual([0, 2, true]);
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    const catalog = createCatalogState(sectionsWithCardsRef.concat([undefined]), []);
+
+    it('should get all props', () => {
+      const levelRef = 'dummyRef';
+      const progression = createProgression({
+        engine: ENGINE.MICROLEARNING,
+        progressionContent: {
+          type: CONTENT_TYPE.LEVEL,
+          ref: levelRef
+        }
+      });
+
+      const mockedStore = createStoreState({
+        levels: [],
+        disciplines: [],
+        chapters: [],
+        slides: [],
+        progression,
+        catalog
+      });
+
+      const result = mapStateToProps(mockedStore);
+      const expected: ConnectedStateProps = {
+        sections: sectionsWithCardsRef.concat([undefined])
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/src/containers/header-slide-title.test.js
+++ b/src/containers/header-slide-title.test.js
@@ -2,16 +2,16 @@
 
 import {createStoreState} from '../__fixtures__/store';
 import {createProgression} from '../__fixtures__/progression';
-
+import {ENGINE, CONTENT_TYPE} from '../const';
 import {mapStateToProps} from './header-slide-title';
 
 describe('header-slide-title', () => {
   it('should return the accurate props', () => {
     const levelRef = 'dummyRef';
     const progression = createProgression({
-      engine: 'microlearning',
+      engine: ENGINE.MICROLEARNING,
       progressionContent: {
-        type: 'level',
+        type: CONTENT_TYPE.LEVEL,
         ref: levelRef
       }
     });
@@ -35,9 +35,9 @@ describe('header-slide-title', () => {
 
   it('should return empty props if the content level is unavailable', () => {
     const progression = createProgression({
-      engine: 'microlearning',
+      engine: ENGINE.MICROLEARNING,
       progressionContent: {
-        type: 'level',
+        type: CONTENT_TYPE.LEVEL,
         ref: '666'
       }
     });

--- a/src/containers/question-slider.test.js
+++ b/src/containers/question-slider.test.js
@@ -5,26 +5,23 @@ import renderer from 'react-test-renderer';
 
 import {ANALYTICS_EVENT_TYPE, QUESTION_TYPE} from '../const';
 import {createFakeAnalytics} from '../utils/tests';
-import {__TEST__} from '../modules/environment';
 import {Component as QuestionSlider} from './question-slider';
 
-if (__TEST__) {
-  describe('QuestionSlider', () => {
-    it('should handle onPress', () => {
-      const handleChange = jest.fn();
-      const analytics = createFakeAnalytics();
-      const analyticsID = 'slider';
-      const component = renderer.create(
-        <QuestionSlider analytics={analytics} onChange={handleChange} min={{}} max={{}} />
-      );
-      const slider = component.root.find(el => el.props.testID === 'slider');
-      slider.props.onValueChange(42.3);
-      slider.props.onSlidingComplete();
-      expect(analytics.logEvent).toHaveBeenCalledWith(ANALYTICS_EVENT_TYPE.SLIDE, {
-        id: analyticsID,
-        questionType: QUESTION_TYPE.SLIDER
-      });
-      expect(handleChange).toHaveBeenCalledWith(42);
+describe('QuestionSlider', () => {
+  it('should handle onPress', () => {
+    const handleChange = jest.fn();
+    const analytics = createFakeAnalytics();
+    const analyticsID = 'slider';
+    const component = renderer.create(
+      <QuestionSlider analytics={analytics} onChange={handleChange} min={{}} max={{}} />
+    );
+    const slider = component.root.find(el => el.props.testID === 'slider');
+    slider.props.onValueChange(42.3);
+    slider.props.onSlidingComplete();
+    expect(analytics.logEvent).toHaveBeenCalledWith(ANALYTICS_EVENT_TYPE.SLIDE, {
+      id: analyticsID,
+      questionType: QUESTION_TYPE.SLIDER
     });
+    expect(handleChange).toHaveBeenCalledWith(42);
   });
-}
+});

--- a/src/modules/equal.js
+++ b/src/modules/equal.js
@@ -1,0 +1,5 @@
+// @flow
+
+import isEqual from 'lodash/fp/isEqual';
+
+export default isEqual;

--- a/src/modules/equal.test.js
+++ b/src/modules/equal.test.js
@@ -1,9 +1,9 @@
 // @flow strict
 
 describe('Compare', () => {
-  describe('shallowEqual', () => {
+  describe('isEqual', () => {
     it('should return true', () => {
-      const shallowEqual = require('./equal').default;
+      const isEqual = require('./equal').default;
       const props = {
         foo: 'bar',
         baz: {
@@ -16,12 +16,12 @@ describe('Compare', () => {
           qux: 'quux'
         }
       };
-      const result = shallowEqual(props, nextProps)
+      const result = isEqual(props, nextProps);
       expect(result).toBeTruthy();
     });
 
     it('should return false', () => {
-      const shallowEqual = require('./equal').default;
+      const isEqual = require('./equal').default;
       const props = {
         foo: 'bar',
         baz: {
@@ -34,7 +34,7 @@ describe('Compare', () => {
           qux: 'quuux'
         }
       };
-      const result = shallowEqual(props, nextProps)
+      const result = isEqual(props, nextProps);
       expect(result).toBeFalsy();
     });
   });

--- a/src/modules/equal.test.js
+++ b/src/modules/equal.test.js
@@ -1,0 +1,41 @@
+// @flow strict
+
+describe('Compare', () => {
+  describe('shallowEqual', () => {
+    it('should return true', () => {
+      const shallowEqual = require('./equal').default;
+      const props = {
+        foo: 'bar',
+        baz: {
+          qux: 'quux'
+        }
+      };
+      const nextProps = {
+        foo: 'bar',
+        baz: {
+          qux: 'quux'
+        }
+      };
+      const result = shallowEqual(props, nextProps)
+      expect(result).toBeTruthy();
+    });
+
+    it('should return false', () => {
+      const shallowEqual = require('./equal').default;
+      const props = {
+        foo: 'bar',
+        baz: {
+          qux: 'quux'
+        }
+      };
+      const nextProps = {
+        foo: 'bar',
+        baz: {
+          qux: 'quuux'
+        }
+      };
+      const result = shallowEqual(props, nextProps)
+      expect(result).toBeFalsy();
+    });
+  });
+});

--- a/src/screens/level-end.test.js
+++ b/src/screens/level-end.test.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import {createStoreState} from '../__fixtures__/store';
+import {createStoreState, createCatalogState} from '../__fixtures__/store';
 import {createQCMGraphic} from '../__fixtures__/questions';
 import {createSlide} from '../__fixtures__/slides';
 import {createDiscipline} from '../__fixtures__/disciplines';
@@ -68,19 +68,7 @@ const disciplineCardTwo = createDisciplineCard({
 
 describe('LevelEnd', () => {
   describe('Props', () => {
-    const catalog = {
-      entities: {
-        cards: {
-          [disciplineCardOne.ref]: {
-            en: disciplineCardOne
-          },
-          [disciplineCardTwo.ref]: {
-            en: disciplineCardTwo
-          }
-        },
-        sections: {}
-      }
-    };
+    const catalog = createCatalogState([], [disciplineCardOne, disciplineCardTwo]);
 
     it('should have learner props', () => {
       const {mapStateToProps} = require('./level-end');

--- a/src/utils/tests.js
+++ b/src/utils/tests.js
@@ -3,24 +3,48 @@
 import * as React from 'react';
 import {Provider} from 'react-redux';
 
+import {createProgression} from '../__fixtures__/progression';
+import {createStoreState} from '../__fixtures__/store';
 import createDataLayer from '../layer/data';
 import createServices from '../services';
 import createStore from '../redux';
 import {__TEST__} from '../modules/environment';
+import {ENGINE, CONTENT_TYPE} from '../const';
 import type {Layout} from '../containers/with-layout';
 import type {State as AnalyticsState} from '../components/analytics-provider';
 
-export const store = createStore(createServices(createDataLayer()));
+export const createFakeStore = <S>(state?: S) => ({
+  ...createStore(createServices(createDataLayer())),
+  getState: () => ({
+    ...createStoreState({
+      levels: [],
+      disciplines: [],
+      chapters: [],
+      slides: [],
+      progression: createProgression({
+        engine: ENGINE.MICROLEARNING,
+        progressionContent: {
+          type: CONTENT_TYPE.LEVEL,
+          ref: 'mod_foo'
+        }
+      })
+    }),
+    ...state
+  })
+});
+
+// export const store = createStore(createServices(createDataLayer()));
 
 // eslint-disable-next-line no-console
 export const handleFakePress = () => console.log('Fake press');
 
 // eslint-disable-next-line flowtype/no-weak-types
-type TestContextProviderProps = {|
+type TestContextProviderProps<S> = {|
+  store?: S,
   children: React.Node
 |};
-export const TestContextProvider = (props: TestContextProviderProps) => (
-  <Provider store={store}>{props.children}</Provider>
+export const TestContextProvider = <S>({store, children}: TestContextProviderProps<S>) => (
+  <Provider store={createFakeStore<S>(store)}>{children}</Provider>
 );
 
 export const fakeError = new Error('Fake error');

--- a/yarn.lock
+++ b/yarn.lock
@@ -8944,6 +8944,11 @@ lodash@^3.3.1:
   resolved "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12148,10 +12148,20 @@ requires-port@^1.0.0:
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+reselect-map@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/reselect-map/-/reselect-map-1.0.4.tgz#fd6836baa0fe2e84d640fe1a7932589a5b0f992f"
+  integrity sha512-ZSep+yODZiuKvgRcF4WX4Az8Gn4MIDpbuWE6M6dOgPeHH8yo+hM07ltpmfu9zdw1iQ7hL8yB0NRbUz6UEXTCjA==
+
 reselect@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
   integrity sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
 <!-- Please add Labels to the PR, and link it to Trello -->
## Detailed purpose of the PR

This PR improves the props comparison in catalog section component to `PureComponent` shallow compare method poor performances on huge props and adds memoize on `mapStateToProps` (on state and on lists items with `reselect-map`).

## Result

The test was made in similar conditions (initial render, scrolling to the longest section, scrolling 25 times on the right to trigger fetching and re-renders, and select a card).

**We reduced about ~82% of useless renders.**

Before: `873`
After: `158`

NB: I noticed 10MB memory usage reduce after this optimization (and the UI never drops under 59fps).

### Testing strategy

- [x] I ensured my code is tested: <!-- (how: ) -->
- [x] I took care to mention breaking changes and extra libs if appropriate: `reselect` & `reselect-map` (for lists)
